### PR TITLE
fix: initialize KEEP_BACKUPS to prevent install crash

### DIFF
--- a/emby-proxy-toolbox.sh
+++ b/emby-proxy-toolbox.sh
@@ -19,6 +19,7 @@ GW_SNIP_CONF="/etc/nginx/snippets/emby-gw-locations.conf"
 GW_HTPASSWD="/etc/nginx/.htpasswd-emby-gw"
 
 TOOL_NAME="emby-proxy-toolbox"
+KEEP_BACKUPS="${KEEP_BACKUPS:-5}"
 # ------------------------------------------------
 
 need_root() { [[ "${EUID}" -eq 0 ]] || { echo "请用 root 运行：sudo bash $0"; exit 1; }; }


### PR DESCRIPTION
### Motivation
- Prevent the script from failing under `set -u` when `KEEP_BACKUPS` is not defined, which could cause an "unbound variable" error during backup pruning.

### Description
- Add `KEEP_BACKUPS="${KEEP_BACKUPS:-5}"` to the global configuration so a safe default (`5`) is always available.

### Testing
- Ran `bash -n emby-proxy-toolbox.sh` to validate script syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4136754248326bf1ac5ce82357126)